### PR TITLE
Remove type definition causing DI compile issue

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -14,10 +14,4 @@
             </argument>
         </arguments>
     </type>
-
-    <type name="Wiringa\DumpServer\Console\ServerDumpCommand">
-        <arguments>
-            <argument name="server" xsi:type="object">dumpServer</argument>
-        </arguments>
-    </type>
 </config>


### PR DESCRIPTION
Hi,

Second type def is actually not required for 2.3.6+ (suppose that also applies for all 2.3.x versions below)
Symfony\Component\VarDumper\Command\ServerDumpCommand constructor is going to be automatically handled by setup:di:compile and dependency injected properly, otherwise it always throws an exception and the command is not available when executing `bin/magento` or its commands

```
...
In ClassReader.php line 26:
                                                                                 
  Class Wiringa\DumpServer\Console\ServerDumpCommand\Interceptor does not exist  

```
